### PR TITLE
Update usage instructions in main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,8 @@ Dependencies:
 - FFmpeg: Audio/video processing (external binary)
 
 Usage:
-    python src/main.py
+    cd src
+    python main.py
 """
 
 import os


### PR DESCRIPTION
Modified the usage section to clarify that the script should be run from the src directory using 'python main.py'.